### PR TITLE
Updating Transformer MLBox's configuration files to account for new schema

### DIFF
--- a/examples/transformer/mlbox.yaml
+++ b/examples/transformer/mlbox.yaml
@@ -7,6 +7,6 @@ version: 0.1
 mlbox_spec_version: 0.1
 
 tasks:
-  - 'tasks/download_data.yaml'
+  - 'tasks/downloaddata.yaml'
   - 'tasks/preprocess.yaml'
   - 'tasks/train.yaml'

--- a/examples/transformer/mlbox.yaml
+++ b/examples/transformer/mlbox.yaml
@@ -1,36 +1,12 @@
+schema_version: 1.0.0
+schema_type: mlbox_inputs
+
 name: transformer
 author: MLPerf Best Practices Working Group
 version: 0.1
 mlbox_spec_version: 0.1
+
 tasks:
-  downloaddata:
-    inputs: {}
-    outputs:
-      raw_dir:
-        description: "Path where the raw data will be downloaded and extracted."
-  preprocess:
-    inputs:
-      raw_dir:
-        description: "Path where the raw data will be downloaded and extracted."
-    outputs:
-      data_dir:
-        description: "Path where the training and evaluation data are saved."
-  train:
-    inputs:
-      data_dir:
-        description: "Path where the training and evaluation data are saved."
-      vocab_file:
-        description: "Path of vocabulary file."
-      bleu_source:
-        description: "Path to source file containing text translation when \
-                      calculating the official BLEU score."
-      bleu_ref:
-        description: "Path to file containing the reference translation for \
-                      calculating the official BLEU score."
-    outputs:
-      mlperf_log_dir:
-        description: "Directory for mlperf log files."
-      model_dir:
-        description: "Directory to save Transformer model training checkpoints."
-      bleu_dir:
-        description: "Directory to save BLEU scores."
+  - 'tasks/download_data.yaml'
+  - 'tasks/preprocess.yaml'
+  - 'tasks/train.yaml'

--- a/examples/transformer/tasks/downloaddata.yaml
+++ b/examples/transformer/tasks/downloaddata.yaml
@@ -1,0 +1,11 @@
+# Schema
+schema_version: 1.0.0
+schema_type: mlbox_task
+
+# Task Inputs
+inputs: {}
+
+
+# Task Outputs
+outputs:
+  raw_dir: workspace/data/translate_ende_raw

--- a/examples/transformer/tasks/downloaddata/default.yaml
+++ b/examples/transformer/tasks/downloaddata/default.yaml
@@ -1,1 +1,0 @@
-raw_dir: workspace/data/translate_ende_raw

--- a/examples/transformer/tasks/preprocess.yaml
+++ b/examples/transformer/tasks/preprocess.yaml
@@ -1,0 +1,11 @@
+# Schema
+schema_version: 1.0.0
+schema_type: mlbox_task
+
+# Task Inputs
+inputs:
+  raw_dir: workspace/data/translate_ende_raw
+
+# Task Outputs
+outputs:
+  data_dir: workspace/data/translate_ende

--- a/examples/transformer/tasks/preprocess/default.yaml
+++ b/examples/transformer/tasks/preprocess/default.yaml
@@ -1,2 +1,0 @@
-raw_dir: workspace/data/translate_ende_raw
-data_dir: workspace/data/translate_ende

--- a/examples/transformer/tasks/train.yaml
+++ b/examples/transformer/tasks/train.yaml
@@ -1,0 +1,16 @@
+# Schema
+schema_version: 1.0.0
+schema_type: mlbox_task
+
+# Task Inputs
+inputs:
+  data_dir: workspace/data/translate_ende
+  parameters_file: workspace/params/debug.parameters.yaml
+  bleu_source: workspace/data/translate_ende_raw/newstest2014.en
+  bleu_ref: workspace/data/translate_ende_raw/newstest2014.de
+
+# Task Outputs
+outputs:
+  mlperf_log_dir: workspace/log
+  model_dir: workspace/model
+  bleu_dir: workspace/bleu

--- a/examples/transformer/tasks/train/default.yaml
+++ b/examples/transformer/tasks/train/default.yaml
@@ -1,7 +1,0 @@
-parameters_file: workspace/params/debug.parameters.yaml
-data_dir: workspace/data/translate_ende
-bleu_source: workspace/data/translate_ende_raw/newstest2014.en
-bleu_ref: workspace/data/translate_ende_raw/newstest2014.de
-mlperf_log_dir: workspace/log
-model_dir: workspace/model
-bleu_dir: workspace/bleu


### PR DESCRIPTION
Transformer configuration files are updated.
 - MLBox definition file does not define tasks and their input/output parameters. Instead, it references task files. It is assumed that the task name equals to task file name.
- Task definition files have been updated and now follow the schema definition.

> This PR is not ready to be merged!

- Do we have parameter description fields as we used to have?
- The meta data parser needs to be re-written to support new MLBox directory structure.