### PR TITLE
MNIST MLBox example.

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -1,0 +1,26 @@
+# MNIST MLBox example
+
+
+Execute in the mlbox root directory. You may need to run `docker` with sudo (`sudo docker ...`). Also, change or
+remove http(s) variables.
+```bash
+# Build docker image
+docker build ./examples/mnist/mlbox/build --build-arg http_proxy=${http_proxy} \
+             --build-arg https_proxy=${https_proxy} -t mlperf/mlbox:mnist
+
+
+# Setup python environment
+virtualenv -p python3 ./env
+source ./env/bin/activate
+pip install mlspeclib
+export PYTHONPATH=$(pwd)
+
+
+# Run 'download' task
+export MLBOX_DOCKER_ARGS="-e http_proxy=${http_proxy} -e https_proxy=${https_proxy}"
+python3 mlbox_docker_run/docker_run.py --no-pull ./examples/mnist/mlbox/run/download.yaml
+
+
+# Run 'train' task
+python3 mlbox_docker_run/docker_run.py --no-pull ./examples/mnist/mlbox/run/train.yaml
+```

--- a/examples/mnist/mlbox/build/Dockerfile
+++ b/examples/mnist/mlbox/build/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:18.04
+MAINTAINER MLPerf MLBox Working Group
+
+# Remove all stopped containers: docker rm $(docker ps -a -q)
+# Remove containers like none:none: docker rmi $(docker images | grep none | awk '{print $3}')
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+            software-properties-common \
+            python3-dev \
+            curl && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    rm get-pip.py
+
+COPY requirements.txt /requirements.txt
+RUN pip3 install --no-cache-dir -r /requirements.txt
+
+COPY mnist.py /workspace/mnist.py
+ENTRYPOINT ["python3", "/workspace/mnist.py"]

--- a/examples/mnist/mlbox/build/mnist.py
+++ b/examples/mnist/mlbox/build/mnist.py
@@ -1,0 +1,161 @@
+
+"""
+https://www.tensorflow.org/tutorials/quickstart/beginner
+Disable GPUs - not all nodes used for testing have GPUs
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
+"""
+
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+import yaml
+import os
+import logging
+import logging.config
+import argparse
+from enum import Enum
+from typing import List
+import numpy as np
+import tensorflow as tf
+from tensorflow_core.python.keras.utils.data_utils import get_file
+
+
+logger = logging.getLogger(__name__)
+
+
+class Task(str, Enum):
+    DownloadData = 'download'
+    Train = 'train'
+
+
+def download(task_args: List[str]) -> None:
+    """ Task: download.
+    Input parameters:
+        --data_dir
+    """
+    logger.info(f"Starting '{Task.DownloadData}' task")
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--data_dir', '--data-dir', type=str, default=None, help="Path to a dataset file.")
+    args = parser.parse_args(args=task_args)
+
+    data_dir = args.data_dir
+    if data_dir is None:
+        raise ValueError("Data directory is not specified (did you use --data-dir=PATH?)")
+    if not data_dir.startswith("/"):
+        logger.warning("Data directory seems to be a relative path.")
+
+    data_file = os.path.join(data_dir, 'mnist.npz')
+    if os.path.exists(data_file):
+        logger.info("MNIST data has already been download (file exists: %s)", data_file)
+        return
+
+    data_file = get_file(
+        fname=data_file,
+        origin='https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz',
+        file_hash='731c5ac602752760c8e48fbffcf8c3b850d9dc2a2aedcf2cc48468fc17b673d1'
+    )
+
+    if not os.path.isfile(data_file):
+        raise ValueError(f"MNIST dataset has not been downloaded - dataset file does not exist: {data_file}")
+    else:
+        logger.info("MNIST dataset has been downloaded.")
+    logger.info("The '%s' task has been completed.", Task.DownloadData)
+
+
+def train(task_args: List[str]) -> None:
+    """ Task: train.
+    Input parameters:
+        --data_dir, --log_dir, --model_dir, --parameters_file
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--data_dir', '--data-dir', type=str, default=None, help="Dataset path.")
+    parser.add_argument('--model_dir', '--model-dir', type=str, default=None, help="Model output directory.")
+    parser.add_argument('--parameters_file', '--parameters-file', type=str, default=None,
+                        help="Parameters default values.")
+    args = parser.parse_args(args=task_args)
+
+    with open(args.parameters_file, 'r') as stream:
+        parameters = yaml.load(stream, Loader=yaml.FullLoader)
+    logger.info("Parameters have been read (%s).", args.parameters_file)
+
+    dataset_file = os.path.join(args.data_dir, 'mnist.npz')
+    with np.load(dataset_file, allow_pickle=True) as f:
+        x_train, y_train = f['x_train'], f['y_train']
+        x_test, y_test = f['x_test'], f['y_test']
+    x_train, x_test = x_train / 255.0, x_test / 255.0
+    logger.info("Dataset has been loaded (%s).", dataset_file)
+
+    model = tf.keras.models.Sequential([
+        tf.keras.layers.Flatten(input_shape=(28, 28)),
+        tf.keras.layers.Dense(128, activation='relu'),
+        tf.keras.layers.Dropout(0.2),
+        tf.keras.layers.Dense(10, activation='softmax')
+    ])
+    logger.info("Model has been built.")
+
+    model.compile(
+        optimizer=parameters.get('optimizer', 'adam'),
+        loss='sparse_categorical_crossentropy',
+        metrics=['accuracy']
+    )
+    logger.info("Model has been compiled.")
+
+    # Train and evaluate
+    model.fit(
+        x_train,
+        y_train,
+        batch_size=parameters.get('batch_size', 32),
+        epochs=parameters.get('train_epochs', 5)
+    )
+    logger.info("Model has been trained.")
+
+    model.evaluate(x_test, y_test, verbose=2)
+    logger.info("Model has been evaluated.")
+
+    model.save(os.path.join(args.model_dir, 'mnist_model'))
+    logger.info("Model has been saved.")
+
+
+def main():
+    """
+    mnist.py task task_specific_parameters...
+    """
+    # noinspection PyBroadException
+    try:
+        parser = argparse.ArgumentParser()
+        parser.add_argument('mlbox_task', type=str, help="Task for this MLBOX.")
+        parser.add_argument('--log_dir', '--log-dir', type=str, required=True, help="Logging directory.")
+        ml_box_args, task_args = parser.parse_known_args()
+
+        logger_config = {
+            "version": 1,
+            "disable_existing_loggers": True,
+            "formatters": {
+                "standard": {"format": "%(asctime)s - %(name)s - %(threadName)s - %(levelname)s - %(message)s"},
+            },
+            "handlers": {
+                "file_handler": {
+                    "class": "logging.FileHandler",
+                    "level": "INFO",
+                    "formatter": "standard",
+                    "filename": os.path.join(ml_box_args.log_dir, f"mlbox_mnist_{ml_box_args.mlbox_task}.log")
+                }
+            },
+            "loggers": {
+                "": {"level": "INFO", "handlers": ["file_handler"]},
+                "__main__": {"level": "NOTSET", "propagate": "yes"},
+                "tensorflow": {"level": "NOTSET", "propagate": "yes"}
+            }
+        }
+        logging.config.dictConfig(logger_config)
+
+        if ml_box_args.mlbox_task == Task.DownloadData:
+            download(task_args)
+        elif ml_box_args.mlbox_task == Task.Train:
+            train(task_args)
+        else:
+            raise ValueError(f"Unknown task: {task_args}")
+    except Exception as err:
+        logger.exception(err)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/mnist/mlbox/build/requirements.txt
+++ b/examples/mnist/mlbox/build/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML==5.3
+tensorflow==2.1.0
+requests[security]

--- a/examples/mnist/mlbox/mlbox.yaml
+++ b/examples/mnist/mlbox/mlbox.yaml
@@ -1,0 +1,12 @@
+schema_version: 1.0.0
+schema_type: mlbox_root
+
+name: mnist
+author: MLPerf Best Practices Working Group
+version: 0.1.0
+mlbox_spec_version: 0.1.0
+
+tasks:
+  - 'tasks/download.yaml'
+  - 'tasks/train.yaml'
+

--- a/examples/mnist/mlbox/mlbox_docker.yaml
+++ b/examples/mnist/mlbox/mlbox_docker.yaml
@@ -1,0 +1,5 @@
+schema_version: 1.0.0
+schema_type: mlbox_docker
+
+image: mlperf/mlbox:mnist
+docker_runtime: docker # nvidia-docker # OR docker

--- a/examples/mnist/mlbox/run/download.yaml
+++ b/examples/mnist/mlbox/run/download.yaml
@@ -1,0 +1,10 @@
+schema_type: mlbox_invoke
+schema_version: 1.0.0
+
+task_name: download
+
+input_binding: {}
+
+output_binding:
+        data_dir: $WORKSPACE/data
+        log_dir: $WORKSPACE/download_logs

--- a/examples/mnist/mlbox/run/train.yaml
+++ b/examples/mnist/mlbox/run/train.yaml
@@ -1,0 +1,12 @@
+schema_type: mlbox_invoke
+schema_version: 1.0.0
+
+task_name: train
+
+input_binding:
+        data_dir: $WORKSPACE/data
+        parameters_file: $WORKSPACE/parameters/default.parameters.yaml
+
+output_binding:
+        log_dir: $WORKSPACE/train_logs
+        model_dir: $WORKSPACE/model

--- a/examples/mnist/mlbox/tasks/download.yaml
+++ b/examples/mnist/mlbox/tasks/download.yaml
@@ -1,0 +1,14 @@
+# Schema
+schema_version: 1.0.0
+schema_type: mlbox_task
+
+# Task Inputs
+inputs: []
+
+# Task Outputs
+outputs:
+        - name: data_dir
+          type: directory
+
+        - name: log_dir
+          type: directory

--- a/examples/mnist/mlbox/tasks/train.yaml
+++ b/examples/mnist/mlbox/tasks/train.yaml
@@ -1,0 +1,18 @@
+# Schema
+schema_version: 1.0.0
+schema_type: mlbox_task
+
+# Task Inputs
+inputs:
+        - name: data_dir
+          type: directory
+
+        - name: parameters_file
+          type: file
+# Task Outputs
+outputs:
+        - name: log_dir
+          type: directory
+
+        - name: model_dir
+          type: directory

--- a/examples/mnist/mlbox/workspace/parameters/default.parameters.yaml
+++ b/examples/mnist/mlbox/workspace/parameters/default.parameters.yaml
@@ -1,0 +1,3 @@
+optimizer: "adam"
+train_epochs: 5
+batch_size: 32


### PR DESCRIPTION
Two tasks are supported:
  - `download` Download MNIST data set.
  - `train` Train MNIST model.

Steps to run MNIST MLBox:
```bash
# Build docker image
docker build ./examples/mnist/mlbox/build --build-arg http_proxy=${http_proxy} \
             --build-arg https_proxy=${https_proxy} -t mlperf/mlbox:mnist


# Setup python environment
virtualenv -p python3 ./env
source ./env/bin/activate
pip install mlspeclib
export PYTHONPATH=$(pwd)


# Run 'download' task
export MLBOX_DOCKER_ARGS="-e http_proxy=${http_proxy} -e https_proxy=${https_proxy}"
python3 mlbox_docker_run/docker_run.py --no-pull ./examples/mnist/mlbox/run/download.yaml


# Run 'train' task
python3 mlbox_docker_run/docker_run.py --no-pull ./examples/mnist/mlbox/run/train.yaml
```