### PR TITLE
403 Forbidden error while using PyPI token 

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,11 +24,17 @@ jobs:
       run: |
         cd mlcommons_box
         python setup.py sdist bdist_wheel
-        cp -avr dist ../
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: sub-mod/gh-action-pypi-publish@master
       with:
+        user: ${{ secrets.PYPI_USER }}
+        verify_metadata: true
+        skip_existing: true
         password: ${{ secrets.PYPI_PASSWORD }}
+        packages_dir: mlcommons_box/dist/
+        repository_url: https://upload.pypi.org/legacy/
+      env:
+        LOGLEVEL: DEBUG
 
   dispatch:
     needs: deploy
@@ -38,5 +44,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.MLCOMMONS_REPO_ACCESS }}
-          repository: mlperf/mlbox
+          repository: sub-mod/mlbox
           event-type: publish-runners

--- a/.github/workflows/runner-publish.yml
+++ b/.github/workflows/runner-publish.yml
@@ -24,11 +24,17 @@ jobs:
       run: |
         cd runners/mlcommons_box_ssh
         python setup.py sdist bdist_wheel
-        cp -avr dist ../../
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: sub-mod/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.MLCOMMONS_SSH_PYPI_TOKEN }}
+        user: ${{ secrets.PYPI_USER }}
+        verify_metadata: true
+        skip_existing: true
+        password: ${{ secrets.PYPI_PASSWORD }}
+        packages_dir: runners/mlcommons_box_ssh/dist/
+        repository_url: https://upload.pypi.org/legacy/
+      env:
+        LOGLEVEL: DEBUG
 
   docker_deploy:
     runs-on: ubuntu-latest
@@ -46,11 +52,17 @@ jobs:
       run: |
         cd runners/mlcommons_box_docker
         python setup.py sdist bdist_wheel
-        cp -avr dist ../../
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: sub-mod/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.MLCOMMONS_DOCKER_PYPI_TOKEN }}
+        user: ${{ secrets.PYPI_USER }}
+        verify_metadata: true
+        skip_existing: true
+        password: ${{ secrets.PYPI_PASSWORD }}
+        packages_dir: runners/mlcommons_box_docker/dist/
+        repository_url: https://upload.pypi.org/legacy/
+      env:
+        LOGLEVEL: DEBUG
 
   singularity_deploy:
     runs-on: ubuntu-latest
@@ -68,8 +80,14 @@ jobs:
       run: |
         cd runners/mlcommons_box_singularity
         python setup.py sdist bdist_wheel
-        cp -avr dist ../../
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: sub-mod/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.MLCOMMONS_SINGULARITY_PYPI_TOKEN }}
+        user: ${{ secrets.PYPI_USER }}
+        verify_metadata: true
+        skip_existing: true
+        password: ${{ secrets.PYPI_PASSWORD }}
+        packages_dir: runners/mlcommons_box_singularity/dist/
+        repository_url: https://upload.pypi.org/legacy/
+      env:
+        LOGLEVEL: DEBUG


### PR DESCRIPTION
```
HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/
Invalid API Token: invalid macaroon!r```

pypi token was working until Sept 11 . Strangely stops working and needs further investigation.
Using PyPI password for now for releasing.

This fix needs to go in to fix the Github workflow.