### PR TITLE
Make `configure` phase optional with docker runner.

### DIFF
--- a/docs/getting-started/mnist.md
+++ b/docs/getting-started/mnist.md
@@ -319,7 +319,8 @@ pip install mlcommons-box-docker mlcommons-box-singularity
 
 
 ### Docker Runner
-Configure MNIST box:
+Configure MNIST box (this is optional step, docker runner checks if image exists, and if does not, runs `configure`
+phase automatically):
 ```
 mlcommons_box_docker configure --mlbox=. --platform=platforms/docker.yaml
 ```

--- a/runners/mlcommons_box_docker/mlcommons_box_docker/docker_run.py
+++ b/runners/mlcommons_box_docker/mlcommons_box_docker/docker_run.py
@@ -24,6 +24,15 @@ class DockerRun(object):
                 env_vars[proxy_var] = os.environ[proxy_var]
         return env_vars
 
+    def image_exists(self, image_name: str) -> bool:
+        """Check if docker image exists.
+        Args:
+            image_name (str): Name of a docker image.
+        Returns:
+            True if image exists, else false.
+        """
+        return self._run_or_die(f"docker inspect --type=image {image_name} > /dev/null 2>&1", die_on_error=False) == 0
+
     def configure(self):
         """Build Docker Image on a current host."""
         image_name: str = self.mlbox.platform.container.image
@@ -42,12 +51,16 @@ class DockerRun(object):
 
     def run(self):
         """Run a box."""
+        image_name: str = self.mlbox.platform.container.image
+        if not self.image_exists(image_name):
+            logger.warning("Docker image (%s) does not exist. Running 'configure' phase.", image_name)
+            self.configure()
+
         # The 'mounts' dictionary maps host path to container path
         mounts, args = self._generate_mounts_and_args()
         print(f"mounts={mounts}, args={args}")
 
         volumes_str = ' '.join(['--volume {}:{}'.format(t[0], t[1]) for t in mounts.items()])
-        image_name: str = self.mlbox.platform.container.image
         runtime: str = self.mlbox.platform.container.runtime
         runtime_arg = "--runtime=" + runtime if runtime is not None else ""
         env_args = ' '.join([f"-e {var}={name}" for var, name in DockerRun.get_env_variables().items()])
@@ -90,7 +103,16 @@ class DockerRun(object):
 
         return mounts, args
 
-    def _run_or_die(self, cmd):
+    def _run_or_die(self, cmd: str, die_on_error: bool = True) -> int:
+        """Execute shell command.
+        Args:
+            cmd(str): Command to execute.
+            die_on_error (bool): If true and shell returns non-zero exit status, raise RuntimeError.
+        Returns:
+            Exit code.
+        """
         print(cmd)
-        if os.system(cmd) != 0:
+        return_code: int = os.system(cmd)
+        if return_code != 0 and die_on_error:
             raise RuntimeError('Command failed: {}'.format(cmd))
+        return return_code


### PR DESCRIPTION
When using docker runner, the `configure` phase is optional now. This runner automatically identifies if it needs to configure mlbox each time it runs a box task.