### PR TITLE
Updating versions of MNIST containers.

### DIFF
--- a/examples/mnist/platforms/docker.yaml
+++ b/examples/mnist/platforms/docker.yaml
@@ -5,4 +5,4 @@ platform:
   name: "docker"
   version: ">=18.01"
 container:
-  image: "mlperf/mlbox:mnist"
+  image: "mlperf/mlbox_mnist:0.0.2"

--- a/examples/mnist/platforms/singularity.yaml
+++ b/examples/mnist/platforms/singularity.yaml
@@ -12,4 +12,4 @@ container:
 
   # Here, I store them in the directory outside of the MLBOX to avoid copying them back to the user host when using
   # runners such as SSH.
-  image: "${HOME}/.mlcommons-box/containers/mlperf_mlbox_mnist-0.0.1.simg"
+  image: "${HOME}/mlcommons-box/containers/mlperf_mlbox_mnist-0.0.2.simg"


### PR DESCRIPTION
Due to upgrade to TensorFlow version 2.1.2:
 - Docker image is renamed from `mlperf/mlbox:mnist` to `mlperf/mlbox_mnist:0.0.2`.
 - Singularity image is renamed from `${HOME}/.mlcommons-box/containers/mlperf_mlbox_mnist-0.0.1.simg` to `${HOME}/mlcommons-box/containers/mlperf_mlbox_mnist-0.0.2.simg`.