### PR TITLE
Updating MLBox test paths for K8S runner unit tests

### DIFF
--- a/runners/mlcommons_box_k8s/mlcommons_box_k8s/tests/test_mlcommons_box_k8s_run.py
+++ b/runners/mlcommons_box_k8s/mlcommons_box_k8s/tests/test_mlcommons_box_k8s_run.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 from mlcommons_box.common import mlbox_metadata, objects
 from mlcommons_box.common.objects import platform_config
@@ -6,9 +7,9 @@ from mlcommons_box_k8s.k8s_run import KubernetesRun
 
 class TestKubernetesRun(TestCase):
     def setUp(self):
-        self.path_to_mlbox = "mlcommons_box_k8s/tests/test_data/test_box"
-        self.path_to_platform = "mlcommons_box_k8s/tests/test_data/test_box/platforms/docker.yaml"
-        self.path_to_task = "mlcommons_box_k8s/tests/test_data/test_box/run/kubernetes.yaml"
+        self.path_to_mlbox = os.path.join(os.path.dirname(__file__), "test_data/test_box")
+        self.path_to_platform = os.path.join(self.path_to_mlbox, "platforms/docker.yaml")
+        self.path_to_task = os.path.join(self.path_to_mlbox, "run/kubernetes.yaml")
         self.mlbox = mlbox_metadata.MLBox(path=self.path_to_mlbox)
         self.mlbox.platform = objects.load_object_from_file(
             file_path=self.path_to_platform,


### PR DESCRIPTION
This is required to make it work with release tests.